### PR TITLE
Fix MINIO_DEFAULT_REGION value from use-east-1 to us-east-1

### DIFF
--- a/test/environment/env-vars.s3.js
+++ b/test/environment/env-vars.s3.js
@@ -9,4 +9,4 @@ process.env.ACTIVE_PREFIX = 'MINIO';
 process.env.MINIO_ENDPOINT = 'http://localhost:9000';
 process.env.MINIO_ACCESS_KEY_ID = 'minio';
 process.env.MINIO_SECRET_KEY = 'miniosecret';
-process.env.MINIO_DEFAULT_REGION = 'use-east-1';
+process.env.MINIO_DEFAULT_REGION = 'us-east-1';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a region identifier in test configuration, ensuring proper test environment setup and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->